### PR TITLE
Fix default route function typo

### DIFF
--- a/app.py
+++ b/app.py
@@ -72,7 +72,7 @@ def clear():
         return error.message,503
 
 @app.route('/',methods=['GET'])
-def deafult():
+def default():
     try:
         return html.unescape('<b>Welcome - please use packages route for example <a href="http://nirarmon33.pythonanywhere.com/packages?package=express&version=latest">http://nirarmon33.pythonanywhere.com/packages?package=express&version=latest</a></b>')
     except DependencyException as error:


### PR DESCRIPTION
## Summary
- fix a typo in `app.py` by renaming `deafult` to `default`

## Testing
- `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
- `flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68554bfe95f48323b95a3e0e2ab6141a